### PR TITLE
Use a module-level logger instead of the root logger

### DIFF
--- a/src/public_ip/_ip.py
+++ b/src/public_ip/_ip.py
@@ -8,6 +8,8 @@ import threading
 import typing
 from queue import Queue
 
+LOGGER = logging.getLogger(__name__)
+
 URLS = [
     "https://api.ipify.org",
     "https://checkip.amazonaws.com",
@@ -25,7 +27,7 @@ def _get_ip(url: str, queue: Queue, timeout: float) -> None:
         r = requests.get(url, timeout=timeout)
         r.raise_for_status()
         ip = r.text.strip()
-        logging.info("Asked %s for our IP -> %s", url, ip)
+        LOGGER.debug("Asked %s for our IP -> %s", url, ip)
         queue.put(ip)
     except (requests.exceptions.HTTPError, requests.exceptions.Timeout):
         pass


### PR DESCRIPTION
Update logging config to create a logger based on `__name__` rather than using the root logger. This way, users who import `public_ip` will be able to interact with the package's logger. 

For example, let's say a user has their own logger configured, and for debugging purposes they only want to see logging messages generated by their script. The following snippet would prevent any `debug` or `info` level logging messages from the `public_ip` package being output to the console. 

```python
import logging

import public_ip

logging.getLogger("public_ip").setLevel(logging.WARNING)
```

This PR also updates logging level to use `debug` rather than `info`.